### PR TITLE
added support for interfaces and fixed cross referenced sub resources

### DIFF
--- a/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/ParserHelper.java
+++ b/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/ParserHelper.java
@@ -174,10 +174,20 @@ public class ParserHelper {
 			if (!path.isEmpty() && !path.startsWith("/")) {
 				path = "/" + path;
 			}
-
-			return path;
 		}
-		return null;
+		List<String> resourceTags = options.getResourceTags();
+        if (resourceTags != null) {
+            for (String resourceTag : resourceTags) {
+                Tag[] tags = doc.tags(resourceTag);
+                if (tags != null && tags.length > 0) {
+                    path = tags[0].text();
+                    path = path.toLowerCase();
+                    path = path.trim().replace(" ", "_");
+                    break;
+                }
+            }
+        }
+		return path;
 	}
 
 	/**


### PR DESCRIPTION
I added support for JAX-RS annotations on interfaces which are supported by Resteasy client side proxies. I also changed the sub resource parsing from stack based (depth-first) to queue based (breadth-first) so that the sub resources furthest from root are left out in case of circular references. There was also a bug that caused only a partial path to be present in deeply nested sub resources.

I've not been able to test this myself but Travis has a pull request verification plugin that could probably be utilized for this.