### PR TITLE
Support the overriden methods respecting superclass methods annotations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
-script: mvn deploy --settings maven_deploy_settings.xml
+script:
+  -  mvn clean test
+after_success:
+  -  test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && mvn deploy -DskipTests=true --settings maven_deploy_settings.xml
 jdk:
 - oraclejdk7
 env:

--- a/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/ApiMethodParser.java
+++ b/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/ApiMethodParser.java
@@ -122,7 +122,7 @@ public class ApiMethodParser {
 		this.parentPath = parentPath;
 		this.methodDoc = methodDoc;
 		this.models = new LinkedHashSet<Model>();
-		this.httpMethod = HttpMethod.fromMethod(methodDoc);
+		this.httpMethod = ParserHelper.resolveMethodHttpMethod(methodDoc);
 		this.parentMethod = null;
 		this.classes = classes;
 		this.typeClasses = typeClasses;
@@ -145,7 +145,7 @@ public class ApiMethodParser {
 		this.translator = options.getTranslator();
 		this.methodDoc = methodDoc;
 		this.models = new LinkedHashSet<Model>();
-		this.httpMethod = HttpMethod.fromMethod(methodDoc);
+		this.httpMethod = ParserHelper.resolveMethodHttpMethod(methodDoc);
 		this.parentPath = parentMethod.getPath();
 		this.parentMethod = parentMethod;
 		this.classes = classes;
@@ -159,7 +159,7 @@ public class ApiMethodParser {
 	 * @return The method with appropriate data set
 	 */
 	public Method parse() {
-		String methodPath = firstNonNull(parsePath(this.methodDoc, this.options), "");
+		String methodPath = ParserHelper.resolveMethodPath(this.methodDoc, this.options);
 		if (this.httpMethod == null && methodPath.isEmpty()) {
 			return null;
 		}
@@ -473,7 +473,8 @@ public class ApiMethodParser {
 
 		// get full list including any beanparam parameter names
 		Set<String> allParamNames = new HashSet<String>(rawParamNames);
-		for (Parameter parameter : this.methodDoc.parameters()) {
+		for (int paramIndex = 0; paramIndex < this.methodDoc.parameters().length; ++paramIndex) {
+            final Parameter parameter = ParserHelper.getParameterWithAnnotations(this.methodDoc, paramIndex);
 			String paramCategory = ParserHelper.paramTypeOf(consumesMultipart, parameter, this.options);
 			// see if its a special composite type e.g. @BeanParam
 			if ("composite".equals(paramCategory)) {
@@ -525,7 +526,8 @@ public class ApiMethodParser {
 		Map<String, String> paramNames = ParserHelper.getMethodParamNameValuePairs(this.methodDoc, allParamNames, this.options.getParamsNameTags(),
 				this.options);
 
-		for (Parameter parameter : this.methodDoc.parameters()) {
+		for (int paramIndex = 0; paramIndex < this.methodDoc.parameters().length; ++paramIndex) {
+            final Parameter parameter = ParserHelper.getParameterWithAnnotations(this.methodDoc, paramIndex);
 			if (!shouldIncludeParameter(this.httpMethod, excludeParams, parameter)) {
 				continue;
 			}

--- a/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/CrossClassApiParser.java
+++ b/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/CrossClassApiParser.java
@@ -1,6 +1,7 @@
 package com.carma.swagger.doclet.parser;
 
 import static com.carma.swagger.doclet.parser.ParserHelper.parsePath;
+import static com.google.common.base.Objects.equal;
 import static com.google.common.base.Objects.firstNonNull;
 import static com.google.common.collect.Maps.uniqueIndex;
 
@@ -279,7 +280,22 @@ public class CrossClassApiParser {
 			methodApi.setDescription(apiDescription);
 		}
 
-		methodApi.getOperations().add(new Operation(parsedMethod));
+        boolean alreadyAdded = false;
+        // skip already added declarations
+        for(Operation operation : methodApi.getOperations()){
+            boolean opParamsEmptyOrNull = operation.getParameters() == null || operation.getParameters().isEmpty();
+            boolean parsedParamsEmptyOrNull = parsedMethod.getParameters() == null || parsedMethod.getParameters().isEmpty();
+            if(operation.getMethod().equals(parsedMethod.getMethod()) &&
+                    ((parsedParamsEmptyOrNull && opParamsEmptyOrNull) ||
+                            (!opParamsEmptyOrNull && !parsedParamsEmptyOrNull &&
+                            operation.getParameters().size() == parsedMethod.getParameters().size())) &&
+                    equal(operation.getNickname(), parsedMethod.getMethodName())){
+                alreadyAdded = true;
+            }
+        }
+        if(!alreadyAdded){
+            methodApi.getOperations().add(new Operation(parsedMethod));
+        }
 	}
 
 }

--- a/swagger-doclet/src/test/java/com/carma/swagger/doclet/apidocs/GenericSuperclassTest.java
+++ b/swagger-doclet/src/test/java/com/carma/swagger/doclet/apidocs/GenericSuperclassTest.java
@@ -1,0 +1,41 @@
+package com.carma.swagger.doclet.apidocs;
+
+import com.carma.swagger.doclet.DocletOptions;
+import com.carma.swagger.doclet.Recorder;
+import com.carma.swagger.doclet.model.ApiDeclaration;
+import com.carma.swagger.doclet.parser.JaxRsAnnotationParser;
+import com.sun.javadoc.RootDoc;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static com.carma.swagger.doclet.apidocs.FixtureLoader.loadFixture;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@SuppressWarnings("javadoc")
+public class GenericSuperclassTest {
+
+	private Recorder recorderMock;
+	private DocletOptions options;
+
+	@Before
+	public void setup() {
+		this.recorderMock = mock(Recorder.class);
+		this.options = new DocletOptions().setRecorder(this.recorderMock).setIncludeSwaggerUi(false);
+	}
+
+	@Test
+	public void testGenericSuperclass() throws IOException {
+		final RootDoc rootDoc = RootDocLoader.fromPath("src/test/resources", "fixtures.genericsuperclass");
+		new JaxRsAnnotationParser(this.options, rootDoc).run();
+
+		final ApiDeclaration api = loadFixture("/fixtures/genericsuperclass/genericsuperclass.json", ApiDeclaration.class);
+		verify(this.recorderMock).record(any(File.class), eq(api));
+	}
+
+}

--- a/swagger-doclet/src/test/resources/fixtures/genericsuperclass/BasicService.java
+++ b/swagger-doclet/src/test/resources/fixtures/genericsuperclass/BasicService.java
@@ -1,0 +1,21 @@
+package fixtures.genericsuperclass;
+
+import fixtures.genericcircular.*;
+import fixtures.genericcircular.MeasurementsQuery;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@SuppressWarnings("javadoc")
+public abstract class BasicService<Entity> {
+
+	@Path("/query/{parentId}")
+	@GET
+	public java.util.List<Entity> findAll(@PathParam("parentId") String parentId) {
+		return null;
+	}
+}

--- a/swagger-doclet/src/test/resources/fixtures/genericsuperclass/User.java
+++ b/swagger-doclet/src/test/resources/fixtures/genericsuperclass/User.java
@@ -1,0 +1,8 @@
+package fixtures.genericsuperclass;
+
+@SuppressWarnings("javadoc")
+public class User {
+
+    String id;
+
+}

--- a/swagger-doclet/src/test/resources/fixtures/genericsuperclass/UsersService.java
+++ b/swagger-doclet/src/test/resources/fixtures/genericsuperclass/UsersService.java
@@ -1,0 +1,21 @@
+package fixtures.genericsuperclass;
+
+import fixtures.genericsuperclass.*;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@SuppressWarnings("javadoc")
+@Path("/users")
+@Produces(MediaType.APPLICATION_JSON)
+public class UsersService extends BasicService<User> {
+
+    @Override
+	public java.util.List<User> findAll(String parentId) {
+		return super.findAll(parentId);
+	}
+}

--- a/swagger-doclet/src/test/resources/fixtures/genericsuperclass/genericsuperclass.json
+++ b/swagger-doclet/src/test/resources/fixtures/genericsuperclass/genericsuperclass.json
@@ -1,0 +1,40 @@
+{
+    "apiVersion": "0",
+    "swaggerVersion": "1.2",
+    "basePath": "http://localhost:8080",
+    "resourcePath": "/users",
+    "apis": [
+        {
+            "path": "/users/query/{parentId}",
+            "operations" : [ {
+                "method" : "GET",
+                "nickname" : "findAll",
+                "type" : "array",
+                "parameters": [ {
+                        "paramType": "path",
+                        "name": "parentId",
+                        "type": "string",
+                        "required" : true
+                    }
+                ],
+                "items" : {
+                    "$ref" : "User"
+                },
+                "produces": [
+                    "application/json"
+                ]
+            } ]
+        }
+    ]
+    ,
+    "models": {
+    	"User": {
+            "id": "User",
+            "properties" : {
+                "id" : {
+                    "type" : "string"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Supporting the correct resource methods overriding. It may be useful if you use generified superclass. At the moment the following example will be generated incorrectly (Entity will be taken as a model, which is not correct): 

```java
// UsersResource.java
@Path("/users")
public class UsersResource extends BasicResource<User> {
    @Override
    public List<User> findAll() {
        return super.findAll();
    }
}

// BasicResource.java
public abstract class BasicResource<Entity> {
    @GET
    @Path("/{parentId}")
    public List<Entity> findAll() {
        return getDAO().findAll();
    }
}
```

P.S. By the way, it would be much better not to override such methods at all. But I'm not sure it is possible to detect the actual type arguments for the superclass correctly within the doclet..