### PR TITLE
Added CookieParam and MatrixParam to the excludeParamAnnotations.

### DIFF
--- a/swagger-doclet/src/main/java/com/carma/swagger/doclet/DocletOptions.java
+++ b/swagger-doclet/src/main/java/com/carma/swagger/doclet/DocletOptions.java
@@ -394,6 +394,8 @@ public class DocletOptions {
 	public DocletOptions() {
 		this.excludeParamAnnotations = new ArrayList<String>();
 		this.excludeParamAnnotations.add("javax.ws.rs.core.Context");
+		this.excludeParamAnnotations.add("javax.ws.rs.CookieParam");
+		this.excludeParamAnnotations.add("javax.ws.rs.MatrixParam");
 
 		this.responseMessageTags = new ArrayList<String>();
 		this.responseMessageTags.add("responseMessage");


### PR DESCRIPTION
CookieParam and MatrixParam are not defined in the [possible parameter types](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#parameter-object) from Swagger.
When they are not excluded, they will become string body paramTypes in the json file.
This is not correct and will break other tools like swagger-to-markup.