### PR TITLE
Fix for issues 81 and 83 

### DIFF
--- a/swagger-doclet/src/main/java/com/carma/swagger/doclet/translator/AnnotationAwareTranslator.java
+++ b/swagger-doclet/src/main/java/com/carma/swagger/doclet/translator/AnnotationAwareTranslator.java
@@ -111,7 +111,7 @@ public class AnnotationAwareTranslator implements Translator {
 			boolean isFileDataType = ParserHelper.isFileParameterDataType(parameter, this.options);
 			if (isFileDataType) {
 				OptionalName res = presentOrMissing("File");
-				this.typeNameCache.put(cacheKey, res);
+				//this.typeNameCache.put(cacheKey, res);
 				return res;
 			}
 		}
@@ -142,7 +142,7 @@ public class AnnotationAwareTranslator implements Translator {
 		} else {
 			name = nameFor(this.rootElement, this.rootElementProperty, type.getType().asClassDoc(), false);
 		}
-		this.typeNameCache.put(type, name);
+		//this.typeNameCache.put(type, name);
 		return name;
 	}
 

--- a/swagger-doclet/src/main/java/com/carma/swagger/doclet/translator/AnnotationAwareTranslator.java
+++ b/swagger-doclet/src/main/java/com/carma/swagger/doclet/translator/AnnotationAwareTranslator.java
@@ -111,7 +111,7 @@ public class AnnotationAwareTranslator implements Translator {
 			boolean isFileDataType = ParserHelper.isFileParameterDataType(parameter, this.options);
 			if (isFileDataType) {
 				OptionalName res = presentOrMissing("File");
-				//this.typeNameCache.put(cacheKey, res);
+				this.typeNameCache.put(cacheKey, res);
 				return res;
 			}
 		}
@@ -142,7 +142,7 @@ public class AnnotationAwareTranslator implements Translator {
 		} else {
 			name = nameFor(this.rootElement, this.rootElementProperty, type.getType().asClassDoc(), false);
 		}
-		//this.typeNameCache.put(type, name);
+		this.typeNameCache.put(type, name);
 		return name;
 	}
 

--- a/swagger-doclet/src/main/java/com/carma/swagger/doclet/translator/QualifiedType.java
+++ b/swagger-doclet/src/main/java/com/carma/swagger/doclet/translator/QualifiedType.java
@@ -49,50 +49,24 @@ public class QualifiedType {
 		return this.type;
 	}
 
-	/**
-	 * {@inheritDoc}
-	 * @see java.lang.Object#hashCode()
-	 */
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		QualifiedType that = (QualifiedType) o;
+
+		if (qualifier != null ? !qualifier.equals(that.qualifier) : that.qualifier != null) return false;
+		if (type != null ? !type.equals(that.type) : that.type != null) return false;
+		return !(typeName != null ? !typeName.equals(that.typeName) : that.typeName != null);
+
+	}
+
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((this.qualifier == null) ? 0 : this.qualifier.hashCode());
-		result = prime * result + ((this.typeName == null) ? 0 : this.typeName.hashCode());
+		int result = qualifier != null ? qualifier.hashCode() : 0;
+		result = 31 * result + (type != null ? type.hashCode() : 0);
+		result = 31 * result + (typeName != null ? typeName.hashCode() : 0);
 		return result;
 	}
-
-	/**
-	 * {@inheritDoc}
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 */
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		QualifiedType other = (QualifiedType) obj;
-		if (this.qualifier == null) {
-			if (other.qualifier != null) {
-				return false;
-			}
-		} else if (!this.qualifier.equals(other.qualifier)) {
-			return false;
-		}
-		if (this.typeName == null) {
-			if (other.typeName != null) {
-				return false;
-			}
-		} else if (!this.typeName.equals(other.typeName)) {
-			return false;
-		}
-		return true;
-	}
-
 }

--- a/swagger-doclet/src/test/java/com/carma/swagger/doclet/apidocs/RootDocLoader.java
+++ b/swagger-doclet/src/test/java/com/carma/swagger/doclet/apidocs/RootDocLoader.java
@@ -10,6 +10,8 @@ import com.sun.tools.javadoc.JavadocTool;
 import com.sun.tools.javadoc.Messager;
 import com.sun.tools.javadoc.ModifierFilter;
 
+import javax.tools.JavaFileObject;
+
 @SuppressWarnings("javadoc")
 public class RootDocLoader {
 
@@ -25,8 +27,22 @@ public class RootDocLoader {
 		subPackages.append(subpackage);
 
 		final JavadocTool javaDoc = JavadocTool.make0(context);
-		return javaDoc.getRootDocImpl("", null, new ModifierFilter(ModifierFilter.ALL_ACCESS), new ListBuffer<String>().toList(),
-				new ListBuffer<String[]>().toList(), false, subPackages.toList(), new ListBuffer<String>().toList(), false, false, false);
+
+
+		return javaDoc.getRootDocImpl(
+				"",
+				null,
+				new ModifierFilter(ModifierFilter.ALL_ACCESS),
+				new ListBuffer<String>().toList(),
+				new ListBuffer<String[]>().toList(),
+				new ListBuffer<JavaFileObject>().toList(),
+				false,
+				subPackages.toList(),
+				new ListBuffer<String>().toList(),
+				false,
+				false,
+				false);
+
 	}
 
 }


### PR DESCRIPTION
issue 83 - updated RootDocLoader to use java 8. (JavadocTool.getRootDocImpl method  has a different signature in Java 8 compared with java 6)
issue 81 - the QualifiedType associated to String[] (or more specific to any_type[]) was identical with the one for String (any_type) (there was a bug in equals/hashcode implementation)