### PR TITLE
fix to support multiple error messages with the same http code in

### DIFF
--- a/swagger-doclet-sample-dropwizard/src/main/resources/swagger-ui-2.1.0/swagger-ui.js
+++ b/swagger-doclet-sample-dropwizard/src/main/resources/swagger-ui-2.1.0/swagger-ui.js
@@ -861,9 +861,10 @@ this["Handlebars"]["templates"]["status_code"] = Handlebars.template({"1":functi
     + escapeExpression(lambda((depth0 != null ? depth0.type : depth0), depth0))
     + "</td>\n      </tr>\n";
 },"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<td width='15%' class='code'>"
-    + escapeExpression(((helper = (helper = helpers.code || (depth0 != null ? depth0.code : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"code","hash":{},"data":data}) : helper)))
-    + "</td>\n<td class=\"markdown\">";
+  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
+  var ugly_code = escapeExpression(((helper = (helper = helpers.code || (depth0 != null ? depth0.code : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"code","hash":{},"data":data}) : helper)));
+  var code = ugly_code.split("_");
+  var buffer = "<td width='15%' class='code'>" + (code.length == 2 ? code[0] : ugly_code) + "</td>\n<td class=\"markdown\">";
   stack1 = ((helper = (helper = helpers.message || (depth0 != null ? depth0.message : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"message","hash":{},"data":data}) : helper));
   if (stack1 != null) { buffer += stack1; }
   buffer += "</td>\n<td width='50%'><span class=\"model-signature\" /></td>\n<td class=\"headers\">\n  <table>\n    <tbody>\n";
@@ -2723,7 +2724,7 @@ SwaggerSpecConverter.prototype.responseMessages = function(operation, existingOp
       if(existingResponse.responseModel) {
         response.schema = {'$ref': existingResponse.responseModel};
       }
-      operation.responses['' + existingResponse.code] = response;
+      operation.responses['' + existingResponse.code + "_" + i] = response;
     }
   }
 


### PR DESCRIPTION
this is a hacky patch to the generated swagger-ui.js which allows it to display multiple error responses with the same http code