### PR TITLE
Inherit Resource-@Path

### DIFF
--- a/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/CrossClassApiParser.java
+++ b/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/CrossClassApiParser.java
@@ -1,6 +1,5 @@
 package com.carma.swagger.doclet.parser;
 
-import static com.carma.swagger.doclet.parser.ParserHelper.parsePath;
 import static com.google.common.base.Objects.equal;
 import static com.google.common.base.Objects.firstNonNull;
 import static com.google.common.collect.Maps.uniqueIndex;
@@ -64,7 +63,7 @@ public class CrossClassApiParser {
 		this.classes = classes;
 		this.typeClasses = typeClasses;
 		this.subResourceClasses = subResourceClasses;
-		this.rootPath = firstNonNull(parsePath(classDoc, options), "");
+		this.rootPath = firstNonNull(ParserHelper.parsePathRecursive(classDoc, options), "");
 		this.swaggerVersion = swaggerVersion;
 		this.apiVersion = apiVersion;
 		this.basePath = basePath;
@@ -92,7 +91,7 @@ public class CrossClassApiParser {
 		this.classes = classes;
 		this.typeClasses = typeClasses;
 		this.subResourceClasses = subResourceClasses;
-		this.rootPath = parentResourcePath + firstNonNull(parsePath(classDoc, options), "");
+		this.rootPath = parentResourcePath + firstNonNull(ParserHelper.parsePathRecursive(classDoc, options), "");
 		this.swaggerVersion = swaggerVersion;
 		this.apiVersion = apiVersion;
 		this.basePath = basePath;
@@ -138,9 +137,9 @@ public class CrossClassApiParser {
 				// skip
 			} else {
 				for (MethodDoc method : currentClassDoc.methods()) {
-					ApiMethodParser methodParser = this.parentMethod == null ? new ApiMethodParser(this.options, this.rootPath, method, this.classes,
-							this.typeClasses, defaultErrorTypeClass) : new ApiMethodParser(this.options, this.parentMethod, method, this.classes,
-							this.typeClasses, defaultErrorTypeClass);
+					ApiMethodParser methodParser = this.parentMethod == null ?
+							new ApiMethodParser(this.options, this.rootPath, method, this.classes, this.typeClasses, defaultErrorTypeClass)
+					      : new ApiMethodParser(this.options, this.parentMethod, method, this.classes, this.typeClasses, defaultErrorTypeClass);
 
 					Method parsedMethod = methodParser.parse();
 					if (parsedMethod == null) {

--- a/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/ParserHelper.java
+++ b/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/ParserHelper.java
@@ -214,6 +214,25 @@ public class ParserHelper {
 	}
 
 	/**
+	 * Parses the path from the annotations of a class or recursively the superclasses
+	 *
+	 * @param classDoc The class
+	 * @param options The doclet options
+	 * @return The path or null if no path related annotations were present
+	 */
+	public static String parsePathRecursive(ClassDoc classDoc, DocletOptions options) {
+		ClassDoc doc = classDoc;
+		do {
+			String path = parsePath(doc, options);
+			if (path != null) {
+				return path;
+			}
+			doc = doc.superclass();
+		} while (hasAncestor(doc));
+		return null;
+	}
+
+	/**
 	 * This verifies that the given numeric values are valid for the given data type and format and returns the comparison.
 	 * If not valid it raises an exception. It ignores null/empty values.
 	 * @param context Additional description for contextualizing the error message

--- a/swagger-doclet/src/test/resources/fixtures/resourceinheritance/AbstractResource.java
+++ b/swagger-doclet/src/test/resources/fixtures/resourceinheritance/AbstractResource.java
@@ -8,6 +8,7 @@ import javax.ws.rs.PathParam;
  * The AbstractResource represents a base resource class
  */
 @SuppressWarnings("javadoc")
+@Path("/foo")
 public abstract class AbstractResource {
 
 	@GET

--- a/swagger-doclet/src/test/resources/fixtures/resourceinheritance/ConcreteResource.java
+++ b/swagger-doclet/src/test/resources/fixtures/resourceinheritance/ConcreteResource.java
@@ -4,7 +4,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
 @SuppressWarnings("javadoc")
-@Path("/foo")
 public class ConcreteResource extends AbstractResource {
 
 	@GET


### PR DESCRIPTION
In grown Code we encountered @Path-Annotation at Resource-Baseclasses instead of Leaf-classes. At least Resteasy supports this. JAX-RS doesnt say much about it (methods and classes can be annotated by @Path and the path-value is combined). Because combining paths over multiple classes doesnt seem useful, only the first encountered Path is taken.