### PR TITLE
merge java-methods only differing by mimetypes into one swagger-operation

### DIFF
--- a/swagger-doclet/src/main/java/com/carma/swagger/doclet/model/Operation.java
+++ b/swagger-doclet/src/main/java/com/carma/swagger/doclet/model/Operation.java
@@ -2,7 +2,10 @@ package com.carma.swagger.doclet.model;
 
 import static com.google.common.base.Strings.emptyToNull;
 
+import java.util.Collection;
 import java.util.List;
+
+import com.google.common.collect.ImmutableList;
 
 public class Operation {
 
@@ -29,6 +32,22 @@ public class Operation {
 	private Operation() {
 	}
 
+	private Operation(Operation o) {
+		this.method = o.method;
+		this.nickname = o.nickname;
+		this.type = o.type;
+		this.format = o.format;
+		this.items = o.items;
+		this.parameters = o.parameters;
+		this.responseMessages = o.responseMessages;
+		this.summary = o.summary;
+		this.notes = o.notes;
+		this.consumes = o.consumes;
+		this.produces = o.produces;
+		this.authorizations = o.authorizations;
+		this.deprecated = o.deprecated;
+	}
+
 	public Operation(Method method) {
 		this.method = method.getMethod();
 		this.nickname = emptyToNull(method.getMethodName());
@@ -37,18 +56,17 @@ public class Operation {
 		if (method.getReturnTypeItemsRef() != null || method.getReturnTypeItemsType() != null) {
 			this.items = new PropertyItems(method.getReturnTypeItemsRef(), method.getReturnTypeItemsType(), method.getReturnTypeItemsFormat(), method.getReturnTypeItemsAllowableValues());
 		}
-		this.parameters = method.getParameters().isEmpty() ? null : method.getParameters();
-		this.responseMessages = method.getResponseMessages().isEmpty() ? null : method.getResponseMessages();
+		this.parameters = method.getParameters().isEmpty() ? null : ImmutableList.copyOf(method.getParameters());
+		this.responseMessages = method.getResponseMessages().isEmpty() ? null : ImmutableList.copyOf(method.getResponseMessages());
 		this.summary = emptyToNull(method.getSummary());
 		this.notes = emptyToNull(method.getNotes());
-		this.consumes = method.getConsumes() == null || method.getConsumes().isEmpty() ? null : method.getConsumes();
-		this.produces = method.getProduces() == null || method.getProduces().isEmpty() ? null : method.getProduces();
+		this.consumes = method.getConsumes() == null || method.getConsumes().isEmpty() ? null : ImmutableList.copyOf(method.getConsumes());
+		this.produces = method.getProduces() == null || method.getProduces().isEmpty() ? null : ImmutableList.copyOf(method.getProduces());
 		this.authorizations = method.getAuthorizations();
 
 		if (method.isDeprecated()) {
 			this.deprecated = "true";
 		}
-
 	}
 
 	public HttpMethod getMethod() {
@@ -104,11 +122,35 @@ public class Operation {
 	}
 
 	/**
+	 * Returns a new Operation with the given consumes. This object itself will not be changed.
+	 * @param consumes
+	 *            consumes to set
+	 * @return new Operations
+	 */
+	public Operation consumes(Collection<String> consumes) {
+		Operation clone = new Operation(this);
+		clone.consumes = consumes == null || consumes.isEmpty() ? null : ImmutableList.copyOf(consumes);
+		return clone;
+	}
+
+	/**
 	 * This gets the produces
 	 * @return the produces
 	 */
 	public List<String> getProduces() {
 		return this.produces;
+	}
+
+	/**
+	 * Returns a new Operation with the given produces. This object itself will not be changed.
+	 * @param produces
+	 *            produces to set
+	 * @return new Operations
+	 */
+	public Operation produces(Collection<String> produces) {
+		Operation clone = new Operation(this);
+		clone.produces = produces == null || produces.isEmpty() ? null : ImmutableList.copyOf(produces);
+		return clone;
 	}
 
 	/**

--- a/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/ApiDeclarationMerger.java
+++ b/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/ApiDeclarationMerger.java
@@ -139,20 +139,16 @@ public class ApiDeclarationMerger {
 		return sb.toString();
 	}
 
-	private <T> T getFirstNonNull(T defaultValue, T... vals) {
-		for (T val : vals) {
-			if (val != null) {
-				return val;
-			}
+	private static <T> T getFirstNonNull(T defaultValue, T val) {
+		if (val != null) {
+			return val;
 		}
 		return defaultValue;
 	}
 
-	private <T> T getFirstNonNullNorVal(T defaultValue, T excludeVal, T... vals) {
-		for (T val : vals) {
-			if (val != null && !val.equals(excludeVal)) {
-				return val;
-			}
+	private static <T> T getFirstNonNullNorVal(T defaultValue, T excludeVal, T val) {
+		if (val != null && !val.equals(excludeVal)) {
+			return val;
 		}
 		return defaultValue;
 	}

--- a/swagger-doclet/src/test/java/com/carma/swagger/doclet/apidocs/ProducesMethodsTest.java
+++ b/swagger-doclet/src/test/java/com/carma/swagger/doclet/apidocs/ProducesMethodsTest.java
@@ -1,0 +1,51 @@
+package com.carma.swagger.doclet.apidocs;
+
+import static com.carma.swagger.doclet.apidocs.FixtureLoader.loadFixture;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.carma.swagger.doclet.DocletOptions;
+import com.carma.swagger.doclet.ObjectMapperRecorder;
+import com.carma.swagger.doclet.Recorder;
+import com.carma.swagger.doclet.model.ApiDeclaration;
+import com.carma.swagger.doclet.parser.JaxRsAnnotationParser;
+import com.sun.javadoc.RootDoc;
+
+@SuppressWarnings("javadoc")
+public class ProducesMethodsTest {
+
+	private Recorder recorderMock;
+	private DocletOptions options;
+
+	@Before
+	public void setup() {
+		this.recorderMock = mock(Recorder.class);
+		this.options = new DocletOptions().setRecorder(this.recorderMock).setIncludeSwaggerUi(false);
+	}
+
+	@Test
+	public void testStart() throws IOException {
+		final RootDoc rootDoc = RootDocLoader.fromPath("src/test/resources", "fixtures.producesmethods");
+		new JaxRsAnnotationParser(this.options, rootDoc).run();
+
+		final ApiDeclaration api = loadFixture("/fixtures/producesmethods/producesmethods.json", ApiDeclaration.class);
+		verify(this.recorderMock).record(any(File.class), eq(api));
+	}
+
+	public static void main(String... args) throws IOException {
+		final Recorder recorder = new ObjectMapperRecorder(null, null, null, null);
+		final DocletOptions options = new DocletOptions().setRecorder(recorder).setIncludeSwaggerUi(false);
+		final RootDoc rootDoc = RootDocLoader.fromPath("src/test/resources", "fixtures.producesmethods");
+		new JaxRsAnnotationParser(options, rootDoc).run();
+		System.out.println("done");
+	}
+
+}

--- a/swagger-doclet/src/test/resources/fixtures/producesconsumes/producesconsumes.json
+++ b/swagger-doclet/src/test/resources/fixtures/producesconsumes/producesconsumes.json
@@ -31,29 +31,10 @@
                         }
                     ],
                     "consumes": [
-                    	"application/json", "application/xml"
+                    	"application/json", "application/xml", "text/plain"
                     ],
                     "produces": [
-                    	"application/json", "application/xml"
-                    ]
-                },
-                {
-                    "method": "POST",
-                    "nickname": "postData2",
-                    "type": "Data",
-                    "parameters": [
-                        {
-                            "paramType": "body",
-                            "name": "data",
-                            "type": "Data",
-                            "required" : true
-                        }
-                    ],
-                    "consumes": [
-                    	"text/plain"
-                    ],
-                    "produces": [
-                    	"text/plain"
+                    	"application/json", "application/xml", "text/plain"
                     ]
                 }
             ]

--- a/swagger-doclet/src/test/resources/fixtures/producesmethods/ProducesMethodsResource.java
+++ b/swagger-doclet/src/test/resources/fixtures/producesmethods/ProducesMethodsResource.java
@@ -1,0 +1,26 @@
+package fixtures.producesmethods;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Resource with multiple methods on the same path but differing produces 
+ */
+@Path("/producesmethods")
+@SuppressWarnings("javadoc")
+public class ProducesMethodsResource {
+
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	public String getDataJson() {
+		return "json";
+	}
+
+	@GET
+	@Produces(MediaType.APPLICATION_XML)
+	public String getDataXml() {
+		return "xml";
+	}
+}

--- a/swagger-doclet/src/test/resources/fixtures/producesmethods/producesmethods.json
+++ b/swagger-doclet/src/test/resources/fixtures/producesmethods/producesmethods.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion" : "0",
+  "swaggerVersion" : "1.2",
+  "basePath" : "http://localhost:8080",
+  "resourcePath" : "/producesmethods",
+  "apis" : [ {
+    "path" : "/producesmethods",
+    "operations" : [ {
+      "method" : "GET",
+      "nickname" : "getDataJson",
+      "type" : "string",
+      "produces" : [ "application/json", "application/xml" ]
+    } ]
+  } ]
+}


### PR DESCRIPTION
Since some time ago, swagger-ui no longer displays methods having multiple differing return types. Only different produces-mimetypes with same return-type are supported. See https://github.com/swagger-api/swagger-spec/issues/146 or https://github.com/swagger-api/swagger-core/issues/521 . 

Doclet can still support multiple java-methods (one java-method per mimetype) by combining them into one Swagger-Operation, which this PR does. 
Unfortunately some doclet-unittests declare multiple methods with same parameters and mimetypes (invalid according to JAX-RS). As quick workaround any methods without mimetypes are omitted by the merge.

BTW, it would be nice to get rid of the (unused?) hashcode and equals-methods in the models. Hashing doesnt work well for changeable objects. I would also prefer immutable objects and empty collections instead of null collections.