### PR TITLE
Inherit documentation from interfaces

### DIFF
--- a/swagger-doclet/src/test/java/com/carma/swagger/doclet/apidocs/InterfaceDocumentationTest.java
+++ b/swagger-doclet/src/test/java/com/carma/swagger/doclet/apidocs/InterfaceDocumentationTest.java
@@ -1,0 +1,41 @@
+package com.carma.swagger.doclet.apidocs;
+
+import com.carma.swagger.doclet.DocletOptions;
+import com.carma.swagger.doclet.Recorder;
+import com.carma.swagger.doclet.model.ApiDeclaration;
+import com.carma.swagger.doclet.parser.JaxRsAnnotationParser;
+import com.sun.javadoc.RootDoc;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static com.carma.swagger.doclet.apidocs.FixtureLoader.loadFixture;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@SuppressWarnings("javadoc")
+public class InterfaceDocumentationTest {
+
+	private Recorder recorderMock;
+	private DocletOptions options;
+
+	@Before
+	public void setup() {
+		this.recorderMock = mock(Recorder.class);
+		this.options = new DocletOptions().setRecorder(this.recorderMock).setIncludeSwaggerUi(false);
+	}
+
+	@Test
+	public void testInterfaceDocumentation() throws IOException {
+		final RootDoc rootDoc = RootDocLoader.fromPath("src/test/resources", "fixtures.interfacedocumentation");
+		new JaxRsAnnotationParser(this.options, rootDoc).run();
+
+		final ApiDeclaration api = loadFixture("/fixtures/interfacedocumentation/interfacedocumentation.json", ApiDeclaration.class);
+		verify(this.recorderMock).record(any(File.class), eq(api));
+	}
+
+}

--- a/swagger-doclet/src/test/resources/fixtures/interfacedocumentation/Implementation.java
+++ b/swagger-doclet/src/test/resources/fixtures/interfacedocumentation/Implementation.java
@@ -1,0 +1,12 @@
+package fixtures.interfacedocumentation;
+
+import javax.ws.rs.Path;
+
+@SuppressWarnings("javadoc")
+public class Implementation implements ParentInterface {
+
+	@Override
+	public String findAll(String param) {
+		return null;
+	}
+}

--- a/swagger-doclet/src/test/resources/fixtures/interfacedocumentation/ParentInterface.java
+++ b/swagger-doclet/src/test/resources/fixtures/interfacedocumentation/ParentInterface.java
@@ -1,0 +1,24 @@
+package fixtures.interfacedocumentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@SuppressWarnings("javadoc")
+@Path("/users")
+public interface ParentInterface {
+
+	/**
+	 * first sentence.
+	 * remaining sentence
+	 */
+	@Path("/query/{param}")
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	@Consumes(MediaType.TEXT_PLAIN)
+	String findAll(@PathParam("param") String param);
+}

--- a/swagger-doclet/src/test/resources/fixtures/interfacedocumentation/interfacedocumentation.json
+++ b/swagger-doclet/src/test/resources/fixtures/interfacedocumentation/interfacedocumentation.json
@@ -1,0 +1,31 @@
+{
+    "apiVersion": "0",
+    "swaggerVersion": "1.2",
+    "basePath": "http://localhost:8080",
+    "resourcePath": "/users",
+    "apis": [
+        {
+            "path": "/users/query/{param}",
+            "operations" : [ {
+                "method" : "GET",
+                "nickname" : "findAll",
+                "type" : "string",
+                "parameters": [ {
+                        "paramType": "path",
+                        "name": "param",
+                        "type": "string",
+                        "required" : true
+                    }
+                ],
+                "summary" : "first sentence.",
+                "notes" : "remaining sentence",
+                "consumes": [
+                    "text/plain"
+                ],
+                "produces": [
+                    "application/json"
+                ]
+            } ]
+        }
+    ]
+}


### PR DESCRIPTION
Until now, only documentation on base classes was inherited. Now also documentation
of methods on inherited interfaces are considered. Currently there is no concatenation
of documentation along the ancestry path.