### PR TITLE
Allow operations on the root path

### DIFF
--- a/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/ApiMethodParser.java
+++ b/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/ApiMethodParser.java
@@ -131,6 +131,9 @@ public class ApiMethodParser {
 		}
 
 		String path = this.parentPath + methodPath;
+                if ("".equals(path)) {
+                    path = "/";
+                }
 
 		// build params
 		List<ApiParameter> parameters = this.generateParameters();


### PR DESCRIPTION
When operations are associated with the application root path using
@Path("") or @Path("/"), make sure that the path is not omitted in the
spec.

This change addresses issue #131.