### PR TITLE
Prevent improper parsing of response 

### DIFF
--- a/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/ApiMethodParser.java
+++ b/swagger-doclet/src/main/java/com/carma/swagger/doclet/parser/ApiMethodParser.java
@@ -46,7 +46,7 @@ public class ApiMethodParser {
 	private static final Pattern GENERIC_RESPONSE_PATTERN = Pattern.compile("(.*)<(.*)>");
 
 	// pattern that can match a code, a description and an optional response model type
-	private static final Pattern[] RESPONSE_MESSAGE_PATTERNS = new Pattern[] { Pattern.compile("(\\d+)([^`]+)(`.*)?") };
+	private static final Pattern[] RESPONSE_MESSAGE_PATTERNS = new Pattern[] { Pattern.compile("(\\d+)([^\\d`]+)(`.*)?") };
 
 	private Method parentMethod;
 	private String parentPath;


### PR DESCRIPTION
Prevent parsing of response from ever using the last digit of response code as the message, even if there is no message
